### PR TITLE
Alias the HCaptcha class so it can be used for dependency injection

### DIFF
--- a/src/HCaptchaServiceProvider.php
+++ b/src/HCaptchaServiceProvider.php
@@ -68,6 +68,8 @@ class HCaptchaServiceProvider extends ServiceProvider
                 );
             }
         });
+
+        $this->app->alias('HCaptcha', HCaptcha::class);
     }
 
     /**


### PR DESCRIPTION
This PR adds `Scyllaly\HCaptcha\HCaptcha::class` as an alias for `HCaptcha` so it can be used for dependency injection.

This can be useful when using HCaptcha with Inertia JS.